### PR TITLE
Cleanup function state connections when destroying instance

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1264,6 +1264,7 @@ GDScript::~GDScript() {
 			// Order matters since clearing the stack may already cause
 			// the GDSCriptFunctionState to be destroyed and thus removed from the list.
 			pending_func_states.remove(E);
+			E->self()->_clear_connections();
 			E->self()->_clear_stack();
 		}
 	}

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -289,6 +289,15 @@ void GDScriptFunctionState::_clear_stack() {
 	}
 }
 
+void GDScriptFunctionState::_clear_connections() {
+	List<Object::Connection> connections;
+	get_signals_connected_to_this(&connections);
+
+	for (Object::Connection &c : connections) {
+		c.signal.disconnect(c.callable);
+	}
+}
+
 void GDScriptFunctionState::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("resume", "arg"), &GDScriptFunctionState::resume, DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("is_valid", "extended_check"), &GDScriptFunctionState::is_valid, DEFVAL(false));

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -623,6 +623,7 @@ public:
 	Variant resume(const Variant &p_arg = Variant());
 
 	void _clear_stack();
+	void _clear_connections();
 
 	GDScriptFunctionState();
 	~GDScriptFunctionState();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
